### PR TITLE
[WIP] Fetch Coveralls build status

### DIFF
--- a/content/build-status-flextgl.html
+++ b/content/build-status-flextgl.html
@@ -1,21 +1,25 @@
 <table class="m-table build-status">
   <thead>
     <tr>
-      <th></th>
+      <th style="border-bottom-width: 0;"></th>
       <th><br/>flextGL</th>
+    </tr>
+    <tr>
+      <th class="m-text-right m-text-middle" style="border-top-width: 0;"><abbr title="combined from all runs">code coverage</abbr></th>
+      <td id="coverage-flextgl"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <th>Python 3.4</th>
+      <th class="m-text-right">Python 3.4</th>
       <td id="flextgl-py34"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
     </tr>
     <tr>
-      <th>Python 3.5</th>
+      <th class="m-text-right">Python 3.5</th>
       <td id="flextgl-py35"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
     </tr>
     <tr>
-      <th>Python 3.6</th>
+      <th class="m-text-right">Python 3.6</th>
       <td id="flextgl-py36"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
     </tr>
   </tbody>

--- a/content/build-status.html
+++ b/content/build-status.html
@@ -1,7 +1,7 @@
 <table class="m-table build-status">
   <thead>
     <tr>
-      <th colspan="3"></th>
+      <th colspan="3" style="border-bottom-width: 0;"></th>
       <th>Corrade</th>
       <th>Magnum</th>
       <th>Magnum<br />Plugins</th>
@@ -9,6 +9,16 @@
       <th>Magnum<br />Integration</th>
       <th>Magnum<br />Examples</th>
       <th>Examples<br />ports</th>
+    </tr>
+    <tr>
+      <th colspan="3" class="m-text-right m-text-middle" style="border-top-width: 0;"><abbr title="combined from all runs, excluding GL code">code coverage</abbr></th>
+      <td id="coverage-corrade"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+      <td id="coverage-magnum"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+      <td id="coverage-magnum-plugins"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+      <td id="coverage-magnum-extras"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+      <td id="coverage-magnum-integration"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+      <td class="m-dim"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+      <td class="m-dim"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
     </tr>
   </thead>
   <tbody>

--- a/content/build-status.js
+++ b/content/build-status.js
@@ -197,6 +197,38 @@ function fetchLatestAppveyorJobs(project, branch) {
     req.send();
 }
 
+function fetchLatestCodecovJobs(project, branch) {
+    var req = window.XDomainRequest ? new XDomainRequest() : new XMLHttpRequest();
+    if(!req) return;
+
+    req.open("GET", 'https://codecov.io/api/gh/' + project + '/branch/' + branch, true);
+    req.responseType = 'json';
+    req.onreadystatechange = function() {
+        if(req.readyState != 4) return;
+
+        //console.log(req.response);
+
+        var repo = req.response['repo']['name'];
+        var id = 'coverage-' + repo;
+        var elem = document.getElementById(id);
+
+        var commit = req.response['commit'];
+        var coverage = (commit['totals']['c']*1.0).toFixed(1);
+        var type;
+        if(commit['state'] != 'complete') type = 'm-info';
+        else if(Math.round(coverage) > 90) type = 'm-success';
+        else if(Math.round(coverage) > 50) type = 'm-warning';
+        else type = 'm-danger';
+
+        var date = commit['updatestamp'];
+        var age = timeDiff(new Date(Date.parse(date)), new Date(Date.now()));
+
+        elem.innerHTML = '<a href="https://codecov.io/gh/mosra/' + repo + '/tree/' + commit['commitid'] + '" title="@ ' + date + '"><strong>' + coverage + '</strong>%<br /><span class="m-text m-small">' + age + '</span></a>';
+        elem.className = type;
+    };
+    req.send();
+}
+
 function fetch() {
     for(var i = 0; i != projects.length; ++i) {
         fetchLatestTravisJobs(projects[i][0], projects[i][1]);
@@ -205,6 +237,12 @@ function fetch() {
            projects[i][0].indexOf('homebrew') === -1 &&
            projects[i][0].indexOf('magnum-singles') === -1)
             fetchLatestAppveyorJobs(projects[i][0], projects[i][1]);
+        /* These don't have coverage reports */
+        if(projects[i][0].indexOf('magnum-examples') == -1 &&
+           projects[i][0].indexOf('magnum-bootstrap') == -1 &&
+           projects[i][0].indexOf('magnum-singles') == -1 &&
+           projects[i][0].indexOf('homebrew') === -1)
+            fetchLatestCodecovJobs(projects[i][0], projects[i][1]);
     }
 }
 


### PR DESCRIPTION
Currently it fails with CORS error. Apparently nobody ever used this API for this purpose (or they don't want anyone to do that). Ugh.

Potential solutions:

- migrate to codecov.io
- extract the percentage from [the badge](https://coveralls.io/repos/github/mosra/magnum/badge.svg?branch=master), search for `\d{2}%</text/>` (but then I lose build age, repo name and everything)