### PR TITLE
Build status for flextGL

### DIFF
--- a/content/build-status-brew.html
+++ b/content/build-status-brew.html
@@ -1,0 +1,18 @@
+<table class="m-table build-status">
+  <thead>
+    <tr>
+      <th></th>
+      <th>Homebrew<br/>packages</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>stable</th>
+      <td id="homebrew-magnum-stable"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+    </tr>
+    <tr>
+      <th>HEAD</th>
+      <td id="homebrew-magnum-head"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+    </tr>
+  </tbody>
+</table>

--- a/content/build-status-flextgl.html
+++ b/content/build-status-flextgl.html
@@ -1,0 +1,22 @@
+<table class="m-table build-status">
+  <thead>
+    <tr>
+      <th></th>
+      <th><br/>flextGL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Python 3.4</th>
+      <td id="flextgl-py34"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+    </tr>
+    <tr>
+      <th>Python 3.5</th>
+      <td id="flextgl-py35"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+    </tr>
+    <tr>
+      <th>Python 3.6</th>
+      <td id="flextgl-py36"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+    </tr>
+  </tbody>
+</table>

--- a/content/build-status-singles.html
+++ b/content/build-status-singles.html
@@ -1,0 +1,14 @@
+<table class="m-table build-status">
+  <thead>
+    <tr>
+      <th></th>
+      <th>Magnum<br/>Singles</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Linux</th>
+      <td id="magnum-singles-linux"><a>&nbsp;<br/><span class="m-text m-small">&nbsp;</span></a></td>
+    </tr>
+  </tbody>
+</table>

--- a/content/build-status.js
+++ b/content/build-status.js
@@ -5,7 +5,10 @@ var projects = [['mosra/corrade', 'master'],
                 ['mosra/magnum-integration', 'master'],
                 ['mosra/magnum-examples', 'master'],
                 ['mosra/magnum-examples', 'ports'],
-                ['mosra/magnum-bootstrap', 'master']];
+                ['mosra/magnum-bootstrap', 'master'],
+                ['mosra/magnum-singles', 'master'],
+                ['mosra/flextgl', 'master'],
+                ['mosra/homebrew-magnum', 'master']];
 var latestTravisJobs = [];
 var travisDone = 0;
 var travisJobIdRe = /JOBID=([a-zA-Z0-9-]+)/
@@ -16,7 +19,7 @@ var appveyorJobIdRe = /APPVEYOR_JOB_NAME=([a-zA-Z0-9-]+)/
 /* Ability to override the projects via query string */
 if(location.search) {
     let params = new URLSearchParams(location.search);
-    projects = []
+    projects = [];
     for(let p of params) projects.push(p);
 }
 
@@ -197,7 +200,11 @@ function fetchLatestAppveyorJobs(project, branch) {
 function fetch() {
     for(var i = 0; i != projects.length; ++i) {
         fetchLatestTravisJobs(projects[i][0], projects[i][1]);
-        fetchLatestAppveyorJobs(projects[i][0], projects[i][1]);
+        /* These are not on AppVeyor */
+        if(projects[i][0].indexOf('flextgl') === -1 &&
+           projects[i][0].indexOf('homebrew') === -1 &&
+           projects[i][0].indexOf('magnum-singles') === -1)
+            fetchLatestAppveyorJobs(projects[i][0], projects[i][1]);
     }
 }
 

--- a/content/build-status.rst
+++ b/content/build-status.rst
@@ -37,7 +37,7 @@ Build Status
 Show builds for:
 
 -   `master branch <{filename}/build-status.rst>`_
--   `next branch <{filename}/build-status.rst?mosra/corrade=next&mosra/magnum=next&mosra/magnum-plugins=next&mosra/magnum-extras=next&mosra/magnum-integration=next&mosra/magnum-examples=next&mosra/magnum-examples=ports-next&mosra/magnum-bootstrap=next>`_
+-   `next branch <{filename}/build-status.rst?mosra/corrade=next&mosra/magnum=next&mosra/magnum-plugins=next&mosra/magnum-extras=next&mosra/magnum-integration=next&mosra/magnum-examples=next&mosra/magnum-examples=ports-next&mosra/magnum-bootstrap=next&mosra/flextgl=next&mosra/magnum-singles=next&mosra/homebrew-magnum=next>`_
 
 `Main repositories`_
 ====================
@@ -48,6 +48,26 @@ Show builds for:
 
         .. raw:: html
             :file: build-status.html
+
+`Related projects`_
+===================
+
+.. container:: m-row
+
+    .. container:: m-col-m-4
+
+        .. raw:: html
+            :file: build-status-flextgl.html
+
+    .. container:: m-col-m-4
+
+        .. raw:: html
+            :file: build-status-singles.html
+
+    .. container:: m-col-m-4
+
+        .. raw:: html
+            :file: build-status-brew.html
 
 `Bootstrap projects`_
 =====================


### PR DESCRIPTION
I didn't have the build status for flextGL among others so it always took me ages to fix build errors there. So I wanted to add them here but the *problem* is that flextGL is hosted on travis-ci.com and not .org. And, so assuming things I made just a branch that used a different TLD, but NO!!! NOT POSSIBLE 401 FORBIDDEN!

So I realized the API is completely different on .com UGH WHY THE HELL DO THEY NEED TO HAVE A COMPLETELY DIFFERENT API ON DOT COM AND DOT ORG?! WHY CAN I USE V2 ONLY ON ORG AND V3 ONLY ON COM?! On one hand I'm able to get almost everything I need via a single query, BUT THE RESULT DOESN'T CONTAIN THE ENV VARS ANYMORE SO IT'S USELESS!

TODO: revisit this once there's API version 71 that hopefully fixes all this crap.

I'm so mad. This is hopefully the last JavaScript I touched in 2019.