### PR TITLE
showcase: fix broken links in raytracing page

### DIFF
--- a/content/showcase/raytracing.rst
+++ b/content/showcase/raytracing.rst
@@ -53,4 +53,4 @@ after around 100 iterations.
 .. block-info:: Source code and documentation
 
     You can find further information and source code of this example
-    :dox:`in the documentation <examples-arcball>`.
+    :dox:`in the documentation <examples-raytracing>`.


### PR DESCRIPTION
Currently, the link at the bottom of [this ray tracing showcase page](https://magnum.graphics/showcase/raytracing/) links to arcball's source. I suppose this link should lead to raytracing source page.